### PR TITLE
Transform complex numbers in codegen stage

### DIFF
--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -6029,17 +6029,7 @@ codegen_pattern_value(compiler *c, pattern_ty p, pattern_context *pc)
 {
     assert(p->kind == MatchValue_kind);
     expr_ty value = p->v.MatchValue.value;
-    if (is_complex_binop(value)) {
-        // A complex literal (e.g. 1+2j) is a valid expression that
-        // can appear as a pattern in a case statement. However,
-        // complex literals are represented as a binary operation in
-        // the AST, which is not a valid expression in a case
-        // statement so we need to handle them specially here.
-        VISIT(c, expr, value->v.BinOp.left);
-        VISIT(c, expr, value->v.BinOp.right);
-        ADDOP_BINARY(c, LOC(value), value->v.BinOp.op);
-    }
-    else if (MATCH_VALUE_EXPR(value)) {
+    if (MATCH_VALUE_EXPR(value) || is_complex_binop(value)) {
         VISIT(c, expr, value);
     }
     else {

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -6030,6 +6030,11 @@ codegen_pattern_value(compiler *c, pattern_ty p, pattern_context *pc)
     assert(p->kind == MatchValue_kind);
     expr_ty value = p->v.MatchValue.value;
     if (MATCH_VALUE_EXPR(value) || is_complex_binop(value)) {
+        // A complex literal (e.g. 1+2j) is a valid expression that
+        // can appear as a pattern in a case statement. However,
+        // complex literals are represented as a binary operation in
+        // the AST, which is not a valid expression in a case
+        // statement so we need to handle them specially here.
         VISIT(c, expr, value);
     }
     else {

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -5362,8 +5362,9 @@ static inline bool is_complex_binop(expr_ty e) {
       && (e->v.BinOp.op == Add || e->v.BinOp.op == Sub)
       && e->v.BinOp.left->kind == Constant_kind
       && e->v.BinOp.right->kind == Constant_kind
-      && (PyComplex_CheckExact(e->v.BinOp.left->v.Constant.value)
-          || PyComplex_CheckExact(e->v.BinOp.right->v.Constant.value));
+      && (PyLong_CheckExact(e->v.BinOp.left->v.Constant.value)
+          || PyFloat_CheckExact(e->v.BinOp.left->v.Constant.value))
+      && PyComplex_CheckExact(e->v.BinOp.right->v.Constant.value);
 }
 
 // Allocate or resize pc->fail_pop to allow for n items to be popped on failure.

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -5357,13 +5357,15 @@ codegen_slice(compiler *c, expr_ty s)
     ((N)->kind == Constant_kind || (N)->kind == Attribute_kind)
 
 // Expressions such as '1+2j' or '1-2j'
-#define COMPLEX_BINOP_CHECK(N) \
-    ((N)->kind == BinOp_kind \
-     && ((N)->v.BinOp.op == Add || (N)->v.BinOp.op == Sub) \
-     && (N)->v.BinOp.left->kind == Constant_kind \
-     && (N)->v.BinOp.right->kind == Constant_kind \
-     && (PyComplex_CheckExact((N)->v.BinOp.left->v.Constant.value) \
-         || PyComplex_CheckExact((N)->v.BinOp.right->v.Constant.value)))
+static inline bool is_complex_binop(expr_ty e) {
+    return e->kind == BinOp_kind
+      && (e->v.BinOp.op == Add || e->v.BinOp.op == Sub)
+      && e->v.BinOp.left->kind == Constant_kind
+      && e->v.BinOp.right->kind == Constant_kind
+      && (PyComplex_CheckExact(e->v.BinOp.left->v.Constant.value)
+          || PyComplex_CheckExact(e->v.BinOp.right->v.Constant.value));
+}
+
 
 // Allocate or resize pc->fail_pop to allow for n items to be popped on failure.
 static int
@@ -6028,15 +6030,15 @@ codegen_pattern_value(compiler *c, pattern_ty p, pattern_context *pc)
 {
     assert(p->kind == MatchValue_kind);
     expr_ty value = p->v.MatchValue.value;
-    if (COMPLEX_BINOP_CHECK(value)) {
-        PyObject *left = value->v.BinOp.left->v.Constant.value;
-        PyObject *right = value->v.BinOp.right->v.Constant.value;
-        PyObject *result = value->v.BinOp.op == Add ?
-            PyNumber_Add(left, right) : PyNumber_Subtract(left, right);
-        if (result == NULL) {
-            return ERROR;
-        }
-        ADDOP_LOAD_CONST(c, LOC(value), result);
+    if (is_complex_binop(value)) {
+        // A complex literal (e.g. 1+2j) is a valid expression that
+        // can appear as a pattern in a case statement. However,
+        // complex literals are represented as a binary operation in
+        // the AST, which is not a valid expression in a case
+        // statement so we need to handle them specially here.
+        VISIT(c, expr, value->v.BinOp.left);
+        VISIT(c, expr, value->v.BinOp.right);
+        ADDOP_BINARY(c, LOC(value), value->v.BinOp.op);
     }
     else if (!MATCH_VALUE_EXPR(value)) {
         const char *e = "patterns may only match literals and attribute lookups";

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -6029,12 +6029,12 @@ codegen_pattern_value(compiler *c, pattern_ty p, pattern_context *pc)
 {
     assert(p->kind == MatchValue_kind);
     expr_ty value = p->v.MatchValue.value;
+    // The permitted expressions in a case pattern are constants,
+    // attribute lookups, and complex literals. However,
+    // complex literals are represented as a binary operation in
+    // the AST rather than a constant, so we need to check for them
+    // manually here.
     if (MATCH_VALUE_EXPR(value) || is_complex_binop(value)) {
-        // A complex literal (e.g. 1+2j) is a valid expression that
-        // can appear as a pattern in a case statement. However,
-        // complex literals are represented as a binary operation in
-        // the AST, which is not a valid expression in a case
-        // statement so we need to handle them specially here.
         VISIT(c, expr, value);
     }
     else {

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -5366,7 +5366,6 @@ static inline bool is_complex_binop(expr_ty e) {
           || PyComplex_CheckExact(e->v.BinOp.right->v.Constant.value));
 }
 
-
 // Allocate or resize pc->fail_pop to allow for n items to be popped on failure.
 static int
 ensure_fail_pop(compiler *c, pattern_context *pc, Py_ssize_t n)
@@ -6040,12 +6039,12 @@ codegen_pattern_value(compiler *c, pattern_ty p, pattern_context *pc)
         VISIT(c, expr, value->v.BinOp.right);
         ADDOP_BINARY(c, LOC(value), value->v.BinOp.op);
     }
-    else if (!MATCH_VALUE_EXPR(value)) {
-        const char *e = "patterns may only match literals and attribute lookups";
-        return _PyCompile_Error(c, LOC(p), e);
+    else if (MATCH_VALUE_EXPR(value)) {
+        VISIT(c, expr, value);
     }
     else {
-        VISIT(c, expr, value);
+        const char *e = "patterns may only match literals and attribute lookups";
+        return _PyCompile_Error(c, LOC(p), e);
     }
     ADDOP_COMPARE(c, LOC(p), Eq);
     ADDOP(c, LOC(p), TO_BOOL);


### PR DESCRIPTION
This fixes cases like:
```python
match x:
    case 1+2j:
        ...
```
which currently raise a syntax error

cc @Eclips4 